### PR TITLE
Make antlr type general.

### DIFF
--- a/experiments/CMakeLists.txt
+++ b/experiments/CMakeLists.txt
@@ -3,32 +3,68 @@ project(AntlrTest)
 
 set(CMAKE_CXX_STANDARD 17)
 
-
-set(ANTLR4CPP_JAR_LOCATION ${CMAKE_CURRENT_SOURCE_DIR}/antlr-4.12.0-complete.jar)
+set(ANTLR4CPP_JAR_LOCATION
+    ${CMAKE_CURRENT_SOURCE_DIR}/antlr-4.12.0-complete.jar)
 
 message("Build command: ${CMAKE_MAKE_PROGRAM}")
 
+# Currently support only one grammar file. TODO: Support multiple grammar files.
 set(GRAMMAR_FILE ${CMAKE_CURRENT_SOURCE_DIR}/SimpleLang.g4)
 
-execute_process(
-  COMMAND java -jar ${ANTLR4CPP_JAR_LOCATION} -Dlanguage=Cpp -o ${CMAKE_CURRENT_SOURCE_DIR}/generated -visitor -listener -package antlrcpptest ${GRAMMAR_FILE}
-)
+file(STRINGS ${GRAMMAR_FILE} file_contents)
+string(REGEX MATCH "^grammar ([A-Za-z0-9]+)" search_result "${file_contents}")
 
-file(GLOB GENERATED_FILES ${CMAKE_CURRENT_SOURCE_DIR}/generated/*.cpp)
-message("Generated files: ${GENERATED_FILES}")
+if(search_result)
+  message("Search result: ${CMAKE_MATCH_1}")
+  set(GRAMMAR_NAME ${CMAKE_MATCH_1})
+else()
+  message(FATAL_ERROR "Your grammar file has no name for grammar.")
+endif()
+
+set(GENERATED_DIR ${CMAKE_CURRENT_SOURCE_DIR}/generated)
+file(MAKE_DIRECTORY ${GENERATED_DIR})
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/generated_header.h.in
+               ${CMAKE_CURRENT_SOURCE_DIR}/generated/generated_header.h @ONLY)
+
+execute_process(
+  COMMAND
+    java -jar ${ANTLR4CPP_JAR_LOCATION} -Dlanguage=Cpp -o
+    ${CMAKE_CURRENT_SOURCE_DIR}/generated -visitor -listener -package
+    antlrcpptest ${GRAMMAR_FILE})
+
+set(GENERATED_SRC_FILES
+    ${GENERATED_DIR}/${GRAMMAR_NAME}Parser.cpp
+    ${GENERATED_DIR}/${GRAMMAR_NAME}Lexer.cpp
+    ${GENERATED_DIR}/${GRAMMAR_NAME}BaseListener.cpp
+    ${GENERATED_DIR}/${GRAMMAR_NAME}BaseVisitor.cpp
+    ${GENERATED_DIR}/${GRAMMAR_NAME}Listener.cpp
+    ${GENERATED_DIR}/${GRAMMAR_NAME}Visitor.cpp)
+
+set(GENERATED_HDR_FILES
+    ${GENERATED_DIR}/${GRAMMAR_NAME}Parser.h
+    ${GENERATED_DIR}/${GRAMMAR_NAME}Lexer.h
+    ${GENERATED_DIR}/${GRAMMAR_NAME}BaseListener.h
+    ${GENERATED_DIR}/${GRAMMAR_NAME}BaseVisitor.h
+    ${GENERATED_DIR}/${GRAMMAR_NAME}Listener.h
+    ${GENERATED_DIR}/${GRAMMAR_NAME}Visitor.h)
 
 add_custom_command(
-        OUTPUT ${GENERATED_FILES}
-        COMMAND java -jar ${ANTLR4CPP_JAR_LOCATION} -Dlanguage=Cpp -o ${CMAKE_CURRENT_SOURCE_DIR}/generated -visitor -listener -package antlrcpptest ${GRAMMAR_FILE}
-        DEPENDS ${GRAMMAR_FILE}
-)
+  OUTPUT ${GENERATED_SRC_FILES} ${GENERATED_HDR_FILES}
+  COMMAND
+    java -jar ${ANTLR4CPP_JAR_LOCATION} -Dlanguage=Cpp -o
+    ${CMAKE_CURRENT_SOURCE_DIR}/generated -visitor -listener -package
+    antlrcpptest ${GRAMMAR_FILE}
+  DEPENDS ${GRAMMAR_FILE})
 
-
-add_library(ir_translator STATIC ir_translater.cpp ${GENERATED_FILES})
-target_include_directories(ir_translator PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/generated ${CMAKE_CURRENT_SOURCE_DIR}/)
+add_library(ir_translator STATIC ir_translater.cpp ${GENERATED_SRC_FILES})
+target_include_directories(
+  ir_translator PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/generated
+                       ${CMAKE_CURRENT_SOURCE_DIR}/)
 target_link_libraries(ir_translator PUBLIC antlr4_static ir_lib)
 target_compile_options(ir_translator PRIVATE -fPIC)
 
 add_executable(AntlrTest main.cpp)
-#target_include_directories(AntlrTest PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/generated ${CMAKE_CURRENT_SOURCE_DIR}/)
+# target_include_directories(AntlrTest PUBLIC
+# ${CMAKE_CURRENT_SOURCE_DIR}/generated ${CMAKE_CURRENT_SOURCE_DIR}/)
 target_link_libraries(AntlrTest PRIVATE antlr4_static ir_translator)

--- a/experiments/generated_header.h.in
+++ b/experiments/generated_header.h.in
@@ -1,0 +1,14 @@
+#ifndef __GENARATED_HEADER_H__
+#define __GENARATED_HEADER_H__
+#include "@GRAMMAR_NAME@Parser.h"
+#include "@GRAMMAR_NAME@Lexer.h"
+#include "@GRAMMAR_NAME@BaseVisitor.h"
+
+using namespace antlr4;
+using namespace antlrcpptest;
+
+using PolyGlotGrammarParser = @GRAMMAR_NAME@Parser;
+using PolyGlotGrammarLexer = @GRAMMAR_NAME@Lexer;
+using PolyGlotGrammarBaseVisitor = @GRAMMAR_NAME@BaseVisitor;
+
+#endif

--- a/experiments/ir_translater.cpp
+++ b/experiments/ir_translater.cpp
@@ -1,8 +1,6 @@
 #include "ir_translater.h"
 
-#include "SimpleLangBaseVisitor.h"
-#include "SimpleLangLexer.h"
-#include "SimpleLangParser.h"
+#include "generated_header.h"
 #include "antlr4-runtime.h"
 // #include "cus.h"
 #include <iostream>
@@ -64,7 +62,7 @@ OneIR ExtractOneIR(std::stack<IM>& stk) {
 }
 
 namespace antlr4 {
-IRPtr TranslateNode(tree::ParseTree* node, SimpleLangParser* parser) {
+IRPtr TranslateNode(tree::ParseTree* node, PolyGlotGrammarParser* parser) {
   assert(node->getTreeType() == antlr4::tree::ParseTreeType::RULE);
 
   std::stack<IM> stk;
@@ -156,12 +154,12 @@ IRPtr TranslateNode(tree::ParseTree* node, SimpleLangParser* parser) {
 
 IRPtr TranslateToIR(std::string input_program) {
   ANTLRInputStream input(input_program);
-  SimpleLangLexer lexer(&input);
+  PolyGlotGrammarLexer lexer(&input);
   CommonTokenStream tokens(&lexer);
 
   tokens.fill();
 
-  SimpleLangParser parser(&tokens);
+  PolyGlotGrammarParser parser(&tokens);
   tree::ParseTree* tree = parser.program();
   if (parser.getNumberOfSyntaxErrors() > 0) {
     return nullptr;


### PR DESCRIPTION
The generated antlr files have grammar specific names. This PR creates a general type name in a header for it.