### PR TITLE
Fix bugs in extract struct & to_string.

### DIFF
--- a/experiments/main.cpp
+++ b/experiments/main.cpp
@@ -94,7 +94,10 @@ int main(int, const char**) {
   )V0G0N";
   */
   std::string a = R"V0G0N(
-    local o1 = setmetatable({}, {__close=function() closed = true end})
+  f=load(function() end)
+  interesting={}
+  interesting[0]=string.rep("A",512)
+  debug.upvaluejoin(f,1.1,f,1)
   )V0G0N";
   ANTLRInputStream input(a);
   PolyGlotGrammarLexer lexer(&input);

--- a/grammars/lua_grammar/input/1.lua
+++ b/grammars/lua_grammar/input/1.lua
@@ -1,4 +1,4 @@
 f=load(function() end)
 interesting={}
 interesting[0]=string.rep("A",512)
-debug.upvaluejoin(f,1,f,1)
+debug.upvaluejoin(f,1.1,f,1)

--- a/srcs/internal/include/mutate.h
+++ b/srcs/internal/include/mutate.h
@@ -3,6 +3,7 @@
 
 // #include <queue>
 #include <map>
+#include <memory>
 #include <set>
 
 #include "frontend.h"

--- a/srcs/internal/srcs/mutate.cpp
+++ b/srcs/internal/srcs/mutate.cpp
@@ -399,7 +399,7 @@ void Mutator::ExtractStructure(IRPtr &root) {
   } else if (int_types_.find(type) != int_types_.end()) {
     root->SetInt(1);
   } else if (float_types_.find(type) != float_types_.end()) {
-    root->SetFloat(1.0);
+    root->SetFloat(1.1);
   }
 }
 

--- a/srcs/internal/srcs/utils.cpp
+++ b/srcs/internal/srcs/utils.cpp
@@ -35,7 +35,7 @@ void trim_string(string &res) {
   for (int i = 0; i < res.size(); i++) {
     if ((res[i] == ';' || res[i] == '}' || res[i] == '{') &&
         i != res.size() - 1) {
-      res[i + 1] = '\n';
+      if (res[i + 1] == ' ') res[i + 1] = '\n';
     }
     if (res[i] == ' ') {
       if (expect_space == false) {

--- a/srcs/polyglot.cc
+++ b/srcs/polyglot.cc
@@ -47,11 +47,11 @@ size_t PolyGlotMutator::generate(const char *test_case) {
       if (g_frontend->Parsable(ir_str)) {
         save_test_cases_.push_back(ir_str);
       } else {
-        // std::cout << "not parsable: " << ir_str << std::endl;
-        // std::cout << "Before: " << test_case << std::endl;
-        continue;
+        std::cout << "not parsable: " << ir_str << std::endl;
+        std::cout << "Before: " << test_case << std::endl;
         // TODO: Make sure everything is parsable.
-        // assert(0);
+        assert(0);
+        continue;
       }
     } else {
       if (g_validator.Validate(ir) ==


### PR DESCRIPTION
1. We should set the float literal to 1.1 instead of 1, which will then be parsed as int.
2. to string will overwrite meaningful char if it is right behind `}`.

We should add more unittests.

Also we should have some utils to report the completeness of a init library.