### PR TITLE
Reduce memory usage by antlr

### DIFF
--- a/tests/simplelang_test.cc
+++ b/tests/simplelang_test.cc
@@ -158,7 +158,7 @@ TEST_F(MutatorTestF, MutateGenerateDifferentTestCases) {
 TEST_F(MutatorTestF, MutateGenerateParsableTestCases) {
   std::string_view test_case = "INT a = 1;";
 
-  for (size_t i = 0; i < 1000; ++i) {
+  for (size_t i = 0; i < 10005; ++i) {
     auto root = frontend->TranslateToIR(test_case.data());
     std::vector<IRPtr> ir_set = CollectAllIRs(root);
 


### PR DESCRIPTION
Antlr will cache some data in parsing. The memory usage of parsing 200K inputs in Lua is over 50G. With this pr, the memory usage is reduced to less than 10G and the memory usage now increases slowly.

However, the memory usage of antlr is still very high. As a comparsion, the parser produced by bison takes less than 2G for over 100M times of parsing.